### PR TITLE
make sure you can compile even if you use java>7

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'java'
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     //test dependencies


### PR DESCRIPTION
without this you get the following when using java>7 :

:mobile:processDebugManifest

UNEXPECTED TOP-LEVEL EXCEPTION:
com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)
    at com.android.dx.cf.direct.DirectClassFile.parse0(DirectClassFile.java:472)
    at com.android.dx.cf.direct.DirectClassFile.parse(DirectClassFile.java:406)
    at com.android.dx.cf.direct.DirectClassFile.parseToInterfacesIfNecessary(DirectClassFile.java:388)
    at com.android.dx.cf.direct.DirectClassFile.getMagic(DirectClassFile.java:251)
    at com.android.dx.command.dexer.Main.processClass(Main.java:704)
    at com.android.dx.command.dexer.Main.processFileBytes(Main.java:673)
    at com.android.dx.command.dexer.Main.access$300(Main.java:82)
    at com.android.dx.command.dexer.Main$1.processFileBytes(Main.java:602)
    at com.android.dx.cf.direct.ClassPathOpener.processArchive(ClassPathOpener.java:284)
    at com.android.dx.cf.direct.ClassPathOpener.processOne(ClassPathOpener.java:166)
    at com.android.dx.cf.direct.ClassPathOpener.process(ClassPathOpener.java:144)
    at com.android.dx.command.dexer.Main.processOne(Main.java:632)
    at com.android.dx.command.dexer.Main.processAllFiles(Main.java:510)
    at com.android.dx.command.dexer.Main.runMonoDex(Main.java:279)
    at com.android.dx.command.dexer.Main.run(Main.java:245)
    at com.android.dx.command.dexer.Main.main(Main.java:214)
    at com.android.dx.command.Main.main(Main.java:106)
...while parsing eu/tobiasheine/bitcoinwatcher/core/PriceConverter.class

1 error; aborting
:mobile:processDebugResources FAILED

FAILURE: Build failed with an exception.
- What went wrong:
  Execution failed for task ':wear:preDexRelease'.
  
  > com.android.ide.common.internal.LoggedErrorException: Failed to run command:
  > /home/ligi/bin/android-sdk/build-tools/21.1.1/dx --dex --output /home/ligi/git/3rd/BitcoinWatcher/wear/build/intermediates/pre-dexed/release/core-4fd11789dbc31a051c0c900b2c1933e9211cb0e6.jar /home/ligi/git/3rd/BitcoinWatcher/core/build/libs/core.jar
  > Error Code:
  >   1
  > Output:
  
    UNEXPECTED TOP-LEVEL EXCEPTION:
    com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)
        at com.android.dx.cf.direct.DirectClassFile.parse0(DirectClassFile.java:472)
        at com.android.dx.cf.direct.DirectClassFile.parse(DirectClassFile.java:406)
        at com.android.dx.cf.direct.DirectClassFile.parseToInterfacesIfNecessary(DirectClassFile.java:388)
        at com.android.dx.cf.direct.DirectClassFile.getMagic(DirectClassFile.java:251)
        at com.android.dx.command.dexer.Main.processClass(Main.java:704)
        at com.android.dx.command.dexer.Main.processFileBytes(Main.java:673)
        at com.android.dx.command.dexer.Main.access$300(Main.java:82)
        at com.android.dx.command.dexer.Main$1.processFileBytes(Main.java:602)
        at com.android.dx.cf.direct.ClassPathOpener.processArchive(ClassPathOpener.java:284)
        at com.android.dx.cf.direct.ClassPathOpener.processOne(ClassPathOpener.java:166)
        at com.android.dx.cf.direct.ClassPathOpener.process(ClassPathOpener.java:144)
        at com.android.dx.command.dexer.Main.processOne(Main.java:632)
        at com.android.dx.command.dexer.Main.processAllFiles(Main.java:510)
        at com.android.dx.command.dexer.Main.runMonoDex(Main.java:279)
        at com.android.dx.command.dexer.Main.run(Main.java:245)
        at com.android.dx.command.dexer.Main.main(Main.java:214)
        at com.android.dx.command.Main.main(Main.java:106)
    ...while parsing eu/tobiasheine/bitcoinwatcher/core/PriceConverter.class
  
    1 error; aborting
- Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 12.255 secs

FAILURE: Build failed with an exception.
- What went wrong:
  Failed to notify build listener.
- Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
